### PR TITLE
Descriptive spec

### DIFF
--- a/default/serverspec/ssh_spec.rb
+++ b/default/serverspec/ssh_spec.rb
@@ -44,7 +44,7 @@ def valid_ciphers
     end
   end
 
-  return ciphers
+  ciphers
 end
 
 def valid_kexs
@@ -76,7 +76,7 @@ def valid_kexs
     end
   end
 
-  return kex
+  kex
 end
 
 def valid_macs
@@ -109,17 +109,17 @@ def valid_macs
     end
   end
 
-  return macs
+  macs
 end
 
 def it_should_define(field, values)
-  its(:content) {
+  its(:content) do
     if values.nil?
       should_not match(/^#{field} .*$/)
     else
       should match(/^#{field} #{values}$/)
     end
-  }
+  end
 end
 
 describe 'SSH owner, group and permissions' do
@@ -190,15 +190,15 @@ describe 'check sshd_config' do
 
   # DTAG SEC: Req 3.04-2
   describe file('/etc/ssh/sshd_config') do
-    it_should_define("Ciphers", valid_ciphers)
+    it_should_define('Ciphers', valid_ciphers)
   end
 
   describe file('/etc/ssh/sshd_config') do
-    it_should_define("MACs", valid_macs)
+    it_should_define('MACs', valid_macs)
   end
 
   describe file('/etc/ssh/sshd_config') do
-    it_should_define("KexAlgorithms", valid_kexs)
+    it_should_define('KexAlgorithms', valid_kexs)
   end
 
   describe file('/etc/ssh/sshd_config') do
@@ -371,15 +371,15 @@ describe 'check ssh_config' do
   end
 
   describe file('/etc/ssh/ssh_config') do
-    it_should_define("Ciphers", valid_ciphers)
+    it_should_define('Ciphers', valid_ciphers)
   end
 
   describe file('/etc/ssh/ssh_config') do
-    it_should_define("MACs", valid_macs)
+    it_should_define('MACs', valid_macs)
   end
 
   describe file('/etc/ssh/ssh_config') do
-    it_should_define("KexAlgorithms", valid_kexs)
+    it_should_define('KexAlgorithms', valid_kexs)
   end
 
   describe file('/etc/ssh/ssh_config') do

--- a/default/serverspec/ssh_spec.rb
+++ b/default/serverspec/ssh_spec.rb
@@ -25,19 +25,19 @@ def valid_ciphers
 
   # adjust ciphers based on OS + release
   case os[:family]
-  when 'Ubuntu'
+  when 'ubuntu'
     case os[:release]
     when '12.04'
       ciphers = ciphers53
     when '14.04'
       ciphers = ciphers66
     end
-  when 'Debian'
+  when 'debian'
     case os[:release]
     when /6\./, /7\./
       ciphers = ciphers53
     end
-  when 'RedHat'
+  when 'redhat'
     case os[:release]
     when '6.4', '6.5'
       ciphers = ciphers53
@@ -55,21 +55,21 @@ def valid_kexs
 
   # adjust KEXs based on OS + release
   case os[:family]
-  when 'Ubuntu'
+  when 'ubuntu'
     case os[:release]
     when '12.04'
       kex = kex59
     when '14.04'
       kex = kex66
     end
-  when 'Debian'
+  when 'debian'
     case os[:release]
     when /6\./
       kex = nil
     when /7\./
       kex = kex59
     end
-  when 'RedHat'
+  when 'redhat'
     case os[:release]
     when '6.4', '6.5'
       kex = nil
@@ -88,21 +88,21 @@ def valid_macs
 
   # adjust MACs based on OS + release
   case os[:family]
-  when 'Ubuntu'
+  when 'ubuntu'
     case os[:release]
     when '12.04'
       macs = macs59
     when '14.04'
       macs = macs66
     end
-  when 'Debian'
+  when 'debian'
     case os[:release]
     when /6\./
       macs = macs53
     when /7\./
       macs = macs59
     end
-  when 'RedHat'
+  when 'redhat'
     case os[:release]
     when '6.4', '6.5'
       macs = macs53

--- a/default/serverspec/ssh_spec.rb
+++ b/default/serverspec/ssh_spec.rb
@@ -17,112 +17,109 @@
 
 require 'spec_helper'
 
-RSpec::Matchers.define :valid_cipher do
-  match do |actual|
+def valid_ciphers
+  # define a set of default ciphers
+  ciphers53 = 'aes256-ctr,aes192-ctr,aes128-ctr'
+  ciphers66 = 'chacha20-poly1305@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr'
+  ciphers = ciphers53
 
-    # define a set of default ciphers
-    ciphers53 = 'aes256-ctr,aes192-ctr,aes128-ctr'
-    ciphers66 = 'chacha20-poly1305@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr'
-    ciphers = ciphers53
-
-    # adjust ciphers based on OS + release
-    case os[:family]
-    when 'Ubuntu'
-      case os[:release]
-      when '12.04'
-        ciphers = ciphers53
-      when '14.04'
-        ciphers = ciphers66
-      end
-    when 'Debian'
-      case os[:release]
-      when /6\./, /7\./
-        ciphers = ciphers53
-      end
-    when 'RedHat'
-      case os[:release]
-      when '6.4', '6.5'
-        ciphers = ciphers53
-      end
+  # adjust ciphers based on OS + release
+  case os[:family]
+  when 'Ubuntu'
+    case os[:release]
+    when '12.04'
+      ciphers = ciphers53
+    when '14.04'
+      ciphers = ciphers66
     end
-
-    actual =~ /^Ciphers #{ciphers}$/
+  when 'Debian'
+    case os[:release]
+    when /6\./, /7\./
+      ciphers = ciphers53
+    end
+  when 'RedHat'
+    case os[:release]
+    when '6.4', '6.5'
+      ciphers = ciphers53
+    end
   end
+
+  return ciphers
 end
 
-RSpec::Matchers.define :valid_kex do
-  match do |actual|
+def valid_kexs
+  # define a set of default KEXs
+  kex66 = 'curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256,diffie-hellman-group14-sha1,diffie-hellman-group-exchange-sha1'
+  kex59 = 'diffie-hellman-group-exchange-sha256,diffie-hellman-group14-sha1,diffie-hellman-group-exchange-sha1'
+  kex = kex59
 
-    # define a set of default KEXs
-    kex66 = 'curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256,diffie-hellman-group14-sha1,diffie-hellman-group-exchange-sha1'
-    kex59 = 'diffie-hellman-group-exchange-sha256,diffie-hellman-group14-sha1,diffie-hellman-group-exchange-sha1'
-    kex = kex59
-
-    # adjust KEXs based on OS + release
-    case os[:family]
-    when 'Ubuntu'
-      case os[:release]
-      when '12.04'
-        kex = kex59
-      when '14.04'
-        kex = kex66
-      end
-    when 'Debian'
-      case os[:release]
-      when /6\./
-        kex = nil
-      when /7\./
-        kex = kex59
-      end
-    when 'RedHat'
-      case os[:release]
-      when '6.4', '6.5'
-        kex = nil
-      end
+  # adjust KEXs based on OS + release
+  case os[:family]
+  when 'Ubuntu'
+    case os[:release]
+    when '12.04'
+      kex = kex59
+    when '14.04'
+      kex = kex66
     end
+  when 'Debian'
+    case os[:release]
+    when /6\./
+      kex = nil
+    when /7\./
+      kex = kex59
+    end
+  when 'RedHat'
+    case os[:release]
+    when '6.4', '6.5'
+      kex = nil
+    end
+  end
 
-    if kex.nil?
-      actual !~ /^KexAlgorithms/
+  return kex
+end
+
+def valid_macs
+  # define a set of default MACs
+  macs66 = 'hmac-sha2-512-etm@openssh.com,hmac-sha2-512,hmac-sha2-256-etm@openssh.com,hmac-sha2-256,umac-128-etm@openssh.com,hmac-ripemd160-etm@openssh.com,hmac-ripemd160'
+  macs59 = 'hmac-sha2-512,hmac-sha2-256,hmac-ripemd160'
+  macs53 = 'hmac-ripemd160,hmac-sha1'
+  macs = macs59
+
+  # adjust MACs based on OS + release
+  case os[:family]
+  when 'Ubuntu'
+    case os[:release]
+    when '12.04'
+      macs = macs59
+    when '14.04'
+      macs = macs66
+    end
+  when 'Debian'
+    case os[:release]
+    when /6\./
+      macs = macs53
+    when /7\./
+      macs = macs59
+    end
+  when 'RedHat'
+    case os[:release]
+    when '6.4', '6.5'
+      macs = macs53
+    end
+  end
+
+  return macs
+end
+
+def it_should_define(field, values)
+  its(:content) {
+    if values.nil?
+      should_not match(/^#{field} .*$/)
     else
-      actual =~ /^KexAlgorithms #{kex}$/
+      should match(/^#{field} #{values}$/)
     end
-  end
-end
-
-RSpec::Matchers.define :valid_mac do
-  match do |actual|
-
-    # define a set of default MACs
-    macs66 = 'hmac-sha2-512-etm@openssh.com,hmac-sha2-512,hmac-sha2-256-etm@openssh.com,hmac-sha2-256,umac-128-etm@openssh.com,hmac-ripemd160-etm@openssh.com,hmac-ripemd160'
-    macs59 = 'hmac-sha2-512,hmac-sha2-256,hmac-ripemd160'
-    macs53 = 'hmac-ripemd160,hmac-sha1'
-    macs = macs59
-
-    # adjust MACs based on OS + release
-    case os[:family]
-    when 'Ubuntu'
-      case os[:release]
-      when '12.04'
-        macs = macs59
-      when '14.04'
-        macs = macs66
-      end
-    when 'Debian'
-      case os[:release]
-      when /6\./
-        macs = macs53
-      when /7\./
-        macs = macs59
-      end
-    when 'RedHat'
-      case os[:release]
-      when '6.4', '6.5'
-        macs = macs53
-      end
-    end
-
-    actual =~ /^MACs #{macs}$/
-  end
+  }
 end
 
 describe 'SSH owner, group and permissions' do
@@ -193,21 +190,15 @@ describe 'check sshd_config' do
 
   # DTAG SEC: Req 3.04-2
   describe file('/etc/ssh/sshd_config') do
-    its(:content) do
-      should valid_cipher
-    end
+    it_should_define("Ciphers", valid_ciphers)
   end
 
   describe file('/etc/ssh/sshd_config') do
-    its(:content) do
-      should valid_mac
-    end
+    it_should_define("MACs", valid_macs)
   end
 
   describe file('/etc/ssh/sshd_config') do
-    its(:content) do
-      should valid_kex
-    end
+    it_should_define("KexAlgorithms", valid_kexs)
   end
 
   describe file('/etc/ssh/sshd_config') do
@@ -380,21 +371,15 @@ describe 'check ssh_config' do
   end
 
   describe file('/etc/ssh/ssh_config') do
-    its(:content) do
-      should valid_cipher
-    end
+    it_should_define("Ciphers", valid_ciphers)
   end
 
   describe file('/etc/ssh/ssh_config') do
-    its(:content) do
-      should valid_mac
-    end
+    it_should_define("MACs", valid_macs)
   end
 
   describe file('/etc/ssh/ssh_config') do
-    its(:content) do
-      should valid_kex
-    end
+    it_should_define("KexAlgorithms", valid_kexs)
   end
 
   describe file('/etc/ssh/ssh_config') do


### PR DESCRIPTION
When running the current version of tests for our crypto algos and a spec fails, we get an output similar to this:
    
    2) check sshd_config File "/etc/ssh/sshd_config" content should valid cipher
        Failure/Error: should valid_cipher
         expected "..." to valid cipher
    
This is not very helpful, since it doesn't tell us what it really expects (e.g. a list of valid ciphers). Best case scenario: you only have to look into the spec file, worst case: your spec has some other error (like OS-detection) and it starts to get really messy.
    
This implementation fixes this issue. It is not as elegant as the current one, but prints very descriptive errors:
    
    2) check ssh_config File "/etc/ssh/ssh_config" content should match /^Ciphers aes256-ctr,aes192-ctr,aes128-ctr$/
