### PR TITLE
feature: add back gcm

### DIFF
--- a/default/serverspec/ssh_spec.rb
+++ b/default/serverspec/ssh_spec.rb
@@ -20,7 +20,7 @@ require 'spec_helper'
 def valid_ciphers
   # define a set of default ciphers
   ciphers53 = 'aes256-ctr,aes192-ctr,aes128-ctr'
-  ciphers66 = 'chacha20-poly1305@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr'
+  ciphers66 = 'chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr'
   ciphers = ciphers53
 
   # adjust ciphers based on OS + release


### PR DESCRIPTION
we originally removed GCM from the cipher chain due to vulnerabilities in OpenSSH. We are adding it back, since any sensible implementation will have had enough time to fix or backport. On top of that, GCM is generally a preferred algorithm. Let's get it back now.

Signed-off-by: Dominik Richter <dominik.richter@gmail.com>